### PR TITLE
fix: prevent ReferenceError when timer is not defined

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,7 +82,7 @@ module.exports = function(app) {
     }
 
     plugin.stop = function() {
-        if (timer) {
+        if (typeof timer !== 'undefined') {
             clearInterval(timer);
             timeout = null;
         }

--- a/index.js
+++ b/index.js
@@ -17,6 +17,7 @@ const shell = require('shelljs');
 
 module.exports = function(app) {
     let plugin = {};
+    let timer = null;
 
     plugin.id = 'signalk-datetime';
     plugin.name = 'Datetime';
@@ -82,7 +83,7 @@ module.exports = function(app) {
     }
 
     plugin.stop = function() {
-        if (typeof timer !== 'undefined') {
+        if (timer) {
             clearInterval(timer);
             timeout = null;
         }


### PR DESCRIPTION
To prevent ReferenceError, variable must be checked for undefined by using typeof operator. I've validated that this works on my installation.

Related issue: https://github.com/tmcolby/signalk-datetime/issues/1